### PR TITLE
Update ADS1X15.cpp

### DIFF
--- a/ADS1X15.cpp
+++ b/ADS1X15.cpp
@@ -13,7 +13,7 @@
 
 
 #define ADS_1015_CONVERSION_DELAY    1
-#define ADS_1115_CONVERSION_DELAY    (((1.0 / _datarate) * 1.1 + 0.00002) * 1e6); // Texas Instruments Timing Delay
+#define ADS_1115_CONVERSION_DELAY    (((1.0 / _datarate) * 1.1 + 0.00002) * 1e6) - 3613.75; // Texas Instruments Timing Delay
 
 //  Kept #defines a bit in line with Adafruit library.
 


### PR DESCRIPTION
Refinement in the conversion delay, minimising the time between reads. Now all four analogue reads to take place about 40% faster than the previous conversion delay.74 -> 44ms for the ADC and 129 -> 78ms for the SSE.
New poll timers have been submitted in a PR for the DIYFB project.